### PR TITLE
BOP-38 Create documentation for installing boundless operator on exisiting cluster

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,9 +29,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_TOKEN }}
-#
-#      - name: Release to Public Repository
-#        uses: softprops/action-gh-release@v1
-#        with:
-#          repository: ranyodh/boundless-tech-preview
-#          token: ${{ secrets.PUBLIC_REPO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <!-- TOC -->
 * [Quick Start](#quick-start)
   * [Install on Kind](#install-on-kind)
+  * [Install on an existing cluster](#install-on-an-existing-cluster)
   * [Install on Amazon VM](#install-on-amazon-vm)
 * [Boundless Operator Blueprints](#boundless-operator-blueprints)
   * [Core Components](#core-components)
@@ -44,15 +45,63 @@
    ```shell
    bctl reset --config blueprint.yaml
    ```
+### Install on an existing cluster
+
+1. Install Boundless Operator
+   ```shell
+   kubectl apply -f https://raw.githubusercontent.com/mirantis/boundless/main/deploy/static/boundless-operator.yaml
+   ```
+2. Wait for boundless operator to be ready
+   ```shell
+   kubectl get deploy -n boundless-system
+   NAME                                    READY   UP-TO-DATE   AVAILABLE   AGE
+   boundless-operator-controller-manager   1/1     1            1           33s
+   ```
+3. Create a blueprint file `blueprint.yaml`:
+   ```yaml
+   apiVersion: boundless.mirantis.com/v1alpha1
+   kind: Blueprint
+   metadata:
+     name: boundless-cluster
+   spec:
+    components:
+      addons:
+        - name: example-server
+          kind: HelmAddon
+          enabled: true
+          namespace: default
+          chart:
+            name: nginx
+            repo: https://charts.bitnami.com/bitnami
+            version: 15.1.1
+            values: |
+              "service":
+                "type": "ClusterIP"
+   ```
+   The above example installs a addon by specifying a helm chart
+4. Apply the blueprint
+   ```shell
+   kubectl apply -f blueprint.yaml
+   ```
+5. After a while, the components specified in the blueprint will be installed:
+   ```shell
+   kubectl get deploy
+   NAME    READY   UP-TO-DATE   AVAILABLE   AGE
+   nginx   1/1     1            1           35s
+   ```
+   
+#### Using `bctl`
+
+[TBD]
 
 ### Install on Amazon VM
 
-### Prerequisites
+#### Prerequisites
 Ensure that following are installed on the system:
 * `k0sctl` (required for installing k0s distribution): https://github.com/k0sproject/k0sctl#installation
 * `terraform` (for creating VMs on AWS)
 
-### Create virtual machines on AWS
+#### Create virtual machines on AWS
 
 There are `terraform` scripts in the `example/` directory that can be used to create machines on AWS.
 
@@ -68,7 +117,7 @@ There are `terraform` scripts in the `example/` directory that can be used to cr
 4. `terraform apply`
 5. `terraform output --raw bop_cluster > ./blueprint.yaml`
 
-### Install Boundless Operator on `k0s`
+#### Install Boundless Operator on `k0s`
 
 1. Install Boundless CLI binary:
    ```shell


### PR DESCRIPTION
The documentation add steps for installing boundless operator on an existing cluster using `kubectl`

Steps for using `bctl` for this will be added after the following ticket is complete: https://mirantis.jira.com/browse/BOP-44