### PR TITLE
[BOP-49] Add PR CI

### DIFF
--- a/.github/development.env
+++ b/.github/development.env
@@ -1,0 +1,3 @@
+GO_VERSION=1.21.3
+
+BINARY=bctl

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -1,0 +1,21 @@
+name: PR
+
+on:
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize']
+    branches: [ "main" ]
+    paths:
+      - '**' # all files otherwise excludes wont work
+      - '!**/**/*.md' # ignore markdown files
+      - '!demo/**' # ignore demos folder
+      - '!sample/**' # ignore samples folder
+      - '!example/**' # ignore examples folder
+
+jobs:
+  vet:
+    uses: ./.github/workflows/vet.yml
+  unit-test:
+      uses: ./.github/workflows/unit.yml
+  build:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,15 @@
+# Workflows
+
+There are two types of workflows in this directory. I would put them in subfolders but GitHub doesn't support that. Since we can't use folders, capital letters are used for the "Caller" workflows and lowercase for the "Job" workflows. This is just a convention to help keep track of what is what.
+
+## Callers
+
+These are the high level workflows that can be associated with what triggers them. PRs, releases, merges, etc. These are made up of jobs that are defined the the other workflows. These are the workflows that you will see in the Actions tab of the repo. By grouping these tasks into parent workflows, the jobs are grouped under one action in the actions tab. They share the smaller 'job' workflows so that they always run the same way.
+
+## Jobs
+
+These are the smaller individual tasks that are used to build up the larger parent workflows. They can be thought of as running unit tests, building the binaries, or linting the code. When you open one of the parent caller actions in the actions tab, they will show these individual jobs.
+
+# Working with workflows
+
+The easiest way to test a workflow is by creating it on your forked repo. This way you have control over the settings and you can manipulate branches anyway you need to trigger the workflow. When testing this way, you should be careful that you are pushing to your repo and not the company's and also make sure to clean everything up in your repo once you have finished testing.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build Binary
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Load environment
+        uses: c-py/action-dotenv-to-setenv@v4
+        with:
+          env-file: .github/development.env
+
+      - name: Setup Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build the binary
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_TOKEN }}
+
+      - name: Upload the binary
+        if: ${{ github.event_name == 'release' || github.event_name == 'push'}} # release or push to main
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.BINARY }}
+          retention-days: 1
+          path: /bin/${{ env.BINARY }}.tar

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,25 @@
+name: Run Unit Tests
+
+on:
+  workflow_call:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Load environment
+        uses: c-py/action-dotenv-to-setenv@v4
+        with:
+          env-file: .github/development.env
+
+      - name: Setup Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run Unit Tests
+        working-directory: .
+        run: make test

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -1,0 +1,25 @@
+name: Vet Go Code
+
+on:
+  workflow_call:
+
+jobs:
+  vet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Load environment
+        uses: c-py/action-dotenv-to-setenv@v4
+        with:
+          env-file: .github/development.env
+
+      - name: Setup Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Vet Go Code
+        working-directory: .
+        run: make vet

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,6 +43,17 @@ archives:
         format: zip
     files:
       - none*
+
+snapshot:
+  # Allows you to change the name of the generated snapshot
+  #
+  # Note that some pipes require this to be semantic version compliant (nfpm,
+  # for example).
+  #
+  # Default is `{{ .Version }}-SNAPSHOT-{{.ShortCommit}}`.
+  # Templates: allowed
+  name_template: 'bctl-{{ .Version }}-{{.ShortCommit}}'
+
 release:
   # release to the public repository
   github:

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,11 @@ reset:
 .PHONY: build-charts
 build-charts:
 	@cd ./charts && make build
+
+.PHONY: test
+test:  ## Run tests.
+	@go test ./... -coverprofile cover.out
+
+.PHONY: vet
+vet: ## Run go vet against code.
+	@go vet ./...

--- a/cmd/kind.go
+++ b/cmd/kind.go
@@ -12,6 +12,6 @@ func installKindCluster(name string, kubeconfig string) error {
 		return fmt.Errorf("failed to create kind cluster %w", err)
 	}
 
-	log.Debug("kubeconfig file for kind cluster: %s", kubeconfig)
+	log.Debugf("kubeconfig file for kind cluster: %s", kubeconfig)
 	return nil
 }

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,22 @@
+# CI
+
+This document describes the CI/CD pipeline for the project. This document is for those developing on the project to understand everything that is running when they make a change to the code. If you are interested in modifying the CI/CD pipeline, see [README](.github/workflows/README.md) in the workflows directory.
+
+## PRs
+
+CI for a PR will trigger whenever a PR is opened, reopened, or pushed. The jobs ran on a PR are meant to be lightweight enough that we can repeatedly run them (each push) but cover enough of the code that we don't have to create a followup PR to fix things that we've missed. The binary for the PR will not be saved from the CI build. The jobs ran on a PR are:
+
+- 'vet' - Check the code changes and make sure they adhere to the standard Golang style guide
+- 'test' - Run the unit tests on the code changes
+- 'build' - Build a binary containing the code changes
+
+## Merging to main
+
+Merging to main runs many of the same tests as a PR to verify that merging the code didn't introduce any new issues. Merging will also run integration tests to verify that the code works with the rest of the system as these tests require more setup and take longer to run. The binary from the build can be found in the artifacts list on the action's page.
+
+TODO: code coverage
+TODO: If you merge a change into main and an issue is found, you will be notified on slack that you have broken main and need to fix it.
+
+## Releases
+
+A release is triggered when a pre-release is created in the github repo. This will run EVERYTHING from scratch. Starting from zero may take more time but this ensures that nothing slips by us before sending out the release. This includes any static code analysis, unit tests, integration tests, and building the binaries. If everything passes, The binary will be uploaded to the release page. This process is documented in [Creating a release](docs/creating-a-release.md).


### PR DESCRIPTION
Pretty much a straight copy from the `bop` repo but with commands adjusted for the `bctl`. 

This is currently building by using the goreleaser setup from the current release process. I'd like to look into separating this so that we can

- Run the same make command in CI as we do for local dev
- Split the builds so they can run in parallel
- Hopefully gain some speed

The followup release PR will upload the artifacts and reuse them during e2e and during the release publish step.

https://mirantis.jira.com/browse/BOP-49