### PR TITLE
Separate the dev and release publish workflows

### DIFF
--- a/.github/workflows/build-and-publish-to-github.yml
+++ b/.github/workflows/build-and-publish-to-github.yml
@@ -4,8 +4,9 @@ on:
   workflow_call:
 
 jobs:
-  build-and-publish:
-    name: Build and publish
+  build-and-publish-dev:
+    name: Build and publish dev
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -24,8 +25,16 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Build dev binary
-        if: ${{ github.event_name == 'push' }}
+      - name: Delete tag and release
+        continue-on-error: true
+        uses: dev-drprasad/delete-tag-and-release@v1.0
+        with:
+          tag_name: dev
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          delete_release: true
+          repo: mirantis/boundless-cli
+
+      - name: Build dev binaries
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
@@ -33,33 +42,53 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_TOKEN }}
 
-      - name: Publish binaries
-        if: ${{ github.event_name == 'push' }} && startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
-        with:
-          name: dev
-          tag_name: dev
-          body: "This is the dev build that always represents the latest commit on the main branch. These binaries change frequiently and are not meant for production use."
-          token: ${{ secrets.PUBLIC_REPO_TOKEN }}
-          repository: mirantis/boundless-cli
-          files: |
-            **/*.tar.gz
-            **/*.zip
+    # Since the temp PAT isn't working, I'm disabling this so the jobs don't show up failed
+      # - name: Publish dev binaries
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     name: dev
+      #     tag_name: dev
+      #     body: "This is the dev build that always represents the latest commit on the main branch. These binaries change frequiently and are not meant for production use."
+      #     token: ${{ secrets.PUBLIC_REPO_TOKEN }}
+      #     repository: mirantis/boundless-cli
+      #     files: |
+      #       **/*.tar.gz
+      #       **/*.zip
 
-      - name: Build and publish release binary
-        if: ${{ github.event_name == 'release' }}
-        uses: goreleaser/goreleaser-action@v5
-        with:
-          version: latest
-          args: --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_TOKEN }}
+  build-and-publish-release:
+    name: Build and publish release
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
 
-      - name: Publish binaries
-        if: ${{ github.event_name == 'release' }}
-        uses: softprops/action-gh-release@v1
-        with:
-          token: ${{ secrets.PUBLIC_REPO_TOKEN }}
-          files: |
-            **/*.tar.gz
-            **/*.zip
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
+
+    - name: Load environment
+      uses: c-py/action-dotenv-to-setenv@v4
+      with:
+        env-file: .github/development.env
+
+    - name: Setup Go ${{ env.GO_VERSION }}
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: Build and publish release binaries
+      uses: goreleaser/goreleaser-action@v5
+      with:
+        version: latest
+        args: --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_TOKEN }}
+
+    # Since the temp PAT isn't working, I'm disabling this so the jobs don't show up failed
+    # - name: Publish binaries to private repo
+    #   uses: softprops/action-gh-release@v1
+    #   with:
+    #     token: ${{ secrets.PUBLIC_REPO_TOKEN }}
+    #     files: |
+    #       **/*.tar.gz
+    #       **/*.zip


### PR DESCRIPTION
Separate the publish steps for merge vs release so that they can't interfere with each other. This also disables pushing the binaries to the private boundless-cli repo since none of the tokens I've tried have worked. I also added a command to skip the tag verification to goreleaser so that we can rerun a merge build if we need to without it failing due to the commit having a `dev` tag (not semver).