### PR TITLE
Quick-fix: fix kind to chart in bctl init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -81,7 +81,7 @@ var defaultComponents = types.Components{
 	Addons: []types.Addons{
 		{
 			Name:      "example-server",
-			Kind:      "HelmAddon",
+			Kind:      "chart",
 			Enabled:   true,
 			Namespace: "default",
 			Chart: types.Chart{


### PR DESCRIPTION
change `Kind:  "HelmAddon"` to `Kind:  "chart"` in bctl init.