### PR TITLE
Suppress warning from runtime clint regarding logger

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -4,7 +4,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// GetClient returns a handle to api server or die.
+// GetClient returns a handle to api server.
 func GetClient(config *KubeConfig) (kubernetes.Interface, error) {
 	cfg, err := config.RESTConfig()
 	if err != nil {

--- a/internal/k8s/create.go
+++ b/internal/k8s/create.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mirantis/boundless-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -21,7 +22,8 @@ func CreateOrUpdate(config *KubeConfig, obj client.Object) error {
 	if err != nil {
 		return err
 	}
-	kubeClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+
+	kubeClient, err := client.New(restConfig, client.Options{Scheme: scheme, WarningHandler: client.WarningHandlerOptions{SuppressWarnings: true}})
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %v", err)
 	}


### PR DESCRIPTION
The Kubernetes runtime-client throw the following error when logger is not initialized:
```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	>  goroutine 1 [running]:
	>  runtime/debug.Stack()
	>  	/usr/local/Cellar/go/1.21.4/libexec/src/runtime/debug/stack.go:24 +0x5e
	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	>  	/Users/rsingh/code/mirantis/boundless-cli/vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go:60 +0xcd
	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc0000c0f00, {0x2615a5f, 0x14})
	>  	/Users/rsingh/code/mirantis/boundless-cli/vendor/sigs.k8s.io/controller-runtime/pkg/log/deleg.go:147 +0x45
	>  github.com/go-logr/logr.Logger.WithName({{0x287ca98, 0xc0000c0f00}, 0x0}, {0x2615a5f?, 0x247f640?})
	>  	/Users/rsingh/code/mirantis/boundless-cli/vendor/github.com/go-logr/logr/logr.go:349 +0x3d
	>  sigs.k8s.io/controller-runtime/pkg/client.newClient(0x28795c8?, {0x0, 0xc000144620, {0x0, 0x0}, 0x0, {0x0, 0x0}, 
...
```

This is because we are currently using in-cluster client to create/update `Blueprint` object, and it expects a logger to be setup. This is not needed for its usage in cli.

This is exiting ticket to try to dynamic client to replace this in future. For now, suppressing these warnings are okay