### PR TITLE
[BOP-188] Fix the release repo

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,7 +56,7 @@ snapshot:
 release:
   # release to the public repository
   github:
-    owner: mirantis
+    owner: mirantiscontainers
     name: boundless
   name_template: "bctl-v{{.Version}}"
 


### PR DESCRIPTION
Fixes the `mirantis` org reference in the release config file that I missed