### PR TITLE
[BOP-97] Allow localhost to be used for k0s in blueprints

### DIFF
--- a/internal/k0sctl/config.go
+++ b/internal/k0sctl/config.go
@@ -1,7 +1,6 @@
 package k0sctl
 
 import (
-	"fmt"
 	"os"
 
 	"gopkg.in/yaml.v2"
@@ -12,7 +11,6 @@ import (
 // GetConfigPath writes the k0sctl config file to a temporary file and returns the path to it
 func GetConfigPath(blueprint types.Blueprint) (string, error) {
 	k0sctlConfig := types.ConvertToK0s(blueprint)
-	fmt.Println(k0sctlConfig)
 
 	data, err := yaml.Marshal(k0sctlConfig)
 	if err != nil {


### PR DESCRIPTION
This change adds support for the [k0sctl localhost](https://github.com/k0sproject/k0sctl?tab=readme-ov-file#spechostslocalhost-mapping-optional) spec in the blueprint. This makes it easy to install k0s as a single node cluster on a local system for example.

Tested by running the example blueprint for the https://mirantis.jira.com/browse/BOP-97 changes

The example blueprint that will be found in the boundless/docs repo would be
```
apiVersion: bctl.mirantis.com/v1alpha1
kind: Blueprint
metadata:
  name: k0s-example
spec:
  kubernetes:
    provider: k0s
    version: v1.28.3+k0s.0
    infra:
      hosts:
      - localhost:
          enabled: true
        role: single
    addons:
      - name: example-server
        kind: chart
        enabled: true
        namespace: default
        chart:
          name: nginx
          repo: https://charts.bitnami.com/bitnami
          version: 15.1.1
          values: |
            "service":
              "type": "ClusterIP"
```

