### PR TITLE
Make localhost optional

### DIFF
--- a/internal/types/common.go
+++ b/internal/types/common.go
@@ -5,9 +5,9 @@ type Metadata struct {
 }
 
 type Host struct {
-	SSH       SSHHost   `yaml:"ssh"`
-	Role      string    `yaml:"role"`
-	LocalHost LocalHost `yaml:"localhost"`
+	SSH       SSHHost    `yaml:"ssh"`
+	Role      string     `yaml:"role"`
+	LocalHost *LocalHost `yaml:"localhost"`
 }
 
 type SSHHost struct {


### PR DESCRIPTION
When I added the option to use localhost for the `host` field, I accidentally made it so an empty value is still used. This changes it so that if the localhost isn't provided, nothing will be sent to k0sctl.