### PR TITLE
Replace json tags with yaml tags in blueprint types

### DIFF
--- a/pkg/types/blueprint.go
+++ b/pkg/types/blueprint.go
@@ -168,8 +168,8 @@ type Addon struct {
 	Kind      string        `yaml:"kind"`
 	Enabled   bool          `yaml:"enabled"`
 	Namespace string        `yaml:"namespace,omitempty"`
-	Chart     *ChartInfo    `json:"chart,omitempty"`
-	Manifest  *ManifestInfo `json:"manifest,omitempty"`
+	Chart     *ChartInfo    `yaml:"chart,omitempty"`
+	Manifest  *ManifestInfo `yaml:"manifest,omitempty"`
 }
 
 // Validate checks the Addon structure and its children
@@ -248,7 +248,7 @@ func (ci *ChartInfo) Validate() error {
 
 // ManifestInfo defines the desired state of manifest
 type ManifestInfo struct {
-	URL string `json:"url"`
+	URL string `yaml:"url"`
 }
 
 // Validate checks the ManifestInfo structure and its children


### PR DESCRIPTION
For some reason, a few fields in some structs used `json` marshalling tag instead of `yaml`. Because of that, after marshalling, we could see `manifest: null` in the resulting YAML files if manifests were not provided. 