### PR TITLE
[BOP-217] Make provider names externally reusable

### DIFF
--- a/internal/distro/provider.go
+++ b/internal/distro/provider.go
@@ -4,16 +4,8 @@ import (
 	"fmt"
 
 	"github.com/mirantiscontainers/boundless-cli/internal/k8s"
+	"github.com/mirantiscontainers/boundless-cli/pkg/constants"
 	"github.com/mirantiscontainers/boundless-cli/pkg/types"
-)
-
-const (
-	// ProviderK0s is the name of the k0s provider
-	ProviderK0s = "k0s"
-	// ProviderKind is the name of the kind provider
-	ProviderKind = "kind"
-	// ProviderExisting is the name of the existing provider
-	ProviderExisting = "existing"
 )
 
 // Provider is the interface for a distro provider
@@ -26,9 +18,9 @@ type Provider interface {
 // GetProvider returns a new provider
 func GetProvider(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig) (Provider, error) {
 	switch blueprint.Spec.Kubernetes.Provider {
-	case ProviderK0s:
+	case constants.ProviderK0s:
 		return NewK0sProvider(blueprint, kubeConfig), nil
-	case ProviderKind:
+	case constants.ProviderKind:
 		return NewKindProvider(blueprint, kubeConfig), nil
 	default:
 		return nil, fmt.Errorf("invalid kubernetes distribution provider: %s", blueprint.Spec.Kubernetes.Provider)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,10 @@
+package constants
+
+const (
+	// ProviderK0s is the name of the k0s provider
+	ProviderK0s = "k0s"
+	// ProviderKind is the name of the kind provider
+	ProviderKind = "kind"
+	// ProviderExisting is the name of the existing provider
+	ProviderExisting = "existing"
+)


### PR DESCRIPTION
To prevent copy-pasting provider names in BOP platform apps such as MKE 4, make the provider names publicly available for reusing.

This came from a code-review in MKE 4 repo - https://github.com/MirantisContainers/mke/pull/10#discussion_r1453620813