### PR TITLE
Fix the k0s version validation

### DIFF
--- a/pkg/types/blueprint.go
+++ b/pkg/types/blueprint.go
@@ -111,7 +111,7 @@ func (k *Kubernetes) Validate() error {
 	// The version can be left empty, but if it's not, it must be a valid k0s semver
 	if k.Version != "" {
 		// This regex gives us semver with an optional "+k0s.0"
-		re, _ := regexp.Compile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+(k[0-9a-zA-Z-]s+(?:\.[0-9a-zA-Z-]+)*))?$`)
+		re, _ := regexp.Compile(`^[v]?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+(k[0-9a-zA-Z-]s+(?:\.[0-9a-zA-Z-]+)*))?$`)
 		if !re.MatchString(k.Version) {
 			return fmt.Errorf("invalid kubernetes.version: %s", k.Version)
 		}


### PR DESCRIPTION
We previously accepted k0s versions with or without the leading 'v'. When I added the validations, I restricted the version to be without a 'v'. I was going to change this so the 'v' is required so as to match their [releases page](https://github.com/k0sproject/k0s/releases) but I noticed that `k0sctl init` does not use a 'v' in the version.

This change makes it so that the k0s version can be with or without the leading 'v'.