### PR TITLE
[BOP-249] Fix the version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,27 @@
 default:  build
 
 BIN_DIR := $(shell pwd)/bin
-VERSION := dev-$(shell git rev-parse --short HEAD)
+
+# LDFLAGS
+VERSION := $(shell git tag --sort=committerdate | tail -1)
+COMMIT := $(shell git rev-parse HEAD)
+DATE := $(shell date -u '+%Y-%m-%d')
+LDFLAGS=-ldflags \
+				" \
+				-X github.com/mirantiscontainers/boundless-cli/cmd.version=${VERSION} \
+				-X github.com/mirantiscontainers/boundless-cli/cmd.commit=${COMMIT} \
+				-X github.com/mirantiscontainers/boundless-cli/cmd.date=${DATE} \
+				"
 
 .PHONY: build
 build:  ## build locally
 	@go mod download
-	@CGO_ENABLED=0 go build -ldflags "-X 'boundless-cli/cmd.version=${VERSION}'" -o ${BIN_DIR}/bctl ./
+	@CGO_ENABLED=0 go build ${LDFLAGS} -o ${BIN_DIR}/bctl ./
 
 .PHONY: install
 install:  ## install locally
 	@go mod download
-	@CGO_ENABLED=0 go build -ldflags "-X 'boundless-cli/cmd.version=${VERSION}'" -o ${GOPATH}/bin/bctl ./
+	@CGO_ENABLED=0 go build ${LDFLAGS} -o ${GOPATH}/bin/bctl ./
 
 .PHONY: init
 init:

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	version, commit, date = "0.0.0-dev", "", ""
+	version, commit, date = "", "", "" // These are always injected at build time
 )
 
 func versionCmd() *cobra.Command {


### PR DESCRIPTION
https://mirantis.jira.com/browse/BOP-249

This fixes the output of `bctl version`. It currently will always print `0.0.0-dev`

```
nneisen@pop-os:~/code/boundless-cli (BOP-249-fix-version): bctl version
Version:    0.0.0-dev
```

I changed the Make command so that we pass information for all of the version vars in `cmd/version.go`.

If there is no tag on the current commit, it will use the most recent tag for the version which is always dev (the tip of main always gets retagged as dev). The commit hash and date will also be added.

```
nneisen@pop-os:~/code/boundless-cli (BOP-249-fix-version): make && bctl version
Version:    dev
Commit:     cd413f2a02f75e221dfa3cfc45acd02a14b91124
Date:       2024-01-23
```

If there is a tag on the current commit, it will be used for the version. This would be the case when CI is doing a build. We can also use these if we need to make a special build for whatever reason.

```
nneisen@pop-os:~/code/boundless-cli (BOP-249-fix-version): git tag nick
nneisen@pop-os:~/code/boundless-cli (BOP-249-fix-version): make && bctl version
Version:    nick
Commit:     cd413f2a02f75e221dfa3cfc45acd02a14b91124
Date:       2024-01-23
```