### PR TITLE
[BOP-281] Handle helm values as yaml

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -32,7 +32,7 @@ func initCmd() *cobra.Command {
 
 func runInit(cmd *cobra.Command, args []string) error {
 	if isKind {
-		return encode(types.ConvertToClusterWithKind("boundless-cluster", defaultComponents))
+		return encode(types.ConvertToClusterWithKind("boundless-cluster", *newDefaultComponents()))
 	}
 
 	// @TODO Include pFlags for k0sctl init
@@ -52,7 +52,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return encode(types.ConvertToClusterWithK0s(k0sConfig, defaultComponents))
+	return encode(types.ConvertToClusterWithK0s(k0sConfig, *newDefaultComponents()))
 }
 
 func encode(blueprint types.Blueprint) error {
@@ -60,38 +60,50 @@ func encode(blueprint types.Blueprint) error {
 	return encoder.Encode(&blueprint)
 }
 
-var defaultComponents = types.Components{
-	Core: &types.Core{
-		Ingress: &types.CoreComponent{
-			Enabled:  true,
-			Provider: "ingress-nginx",
-			Config: dig.Mapping{
-				"controller": dig.Mapping{
-					"service": dig.Mapping{
-						"type": "NodePort",
-						"nodePorts": dig.Mapping{
-							"http":  30000,
-							"https": 30001,
+// newDefaultComponents returns a default components object
+func newDefaultComponents() *types.Components {
+	ingressValues := []byte(`service:
+  type: ClusterIP
+`)
+
+	values := dig.Mapping{}
+	if err := yaml.Unmarshal(ingressValues, &values); err != nil {
+		panic(err)
+	}
+
+	components := &types.Components{
+		Core: &types.Core{
+			Ingress: &types.CoreComponent{
+				Enabled:  true,
+				Provider: "ingress-nginx",
+				Config: dig.Mapping{
+					"controller": dig.Mapping{
+						"service": dig.Mapping{
+							"type": "NodePort",
+							"nodePorts": dig.Mapping{
+								"http":  30000,
+								"https": 30001,
+							},
 						},
 					},
 				},
 			},
 		},
-	},
-	Addons: []types.Addon{
-		{
-			Name:      "example-server",
-			Kind:      constants.AddonChart,
-			Enabled:   true,
-			Namespace: "default",
-			Chart: &types.ChartInfo{
-				Name:    "nginx",
-				Repo:    "https://charts.bitnami.com/bitnami",
-				Version: "15.1.1",
-				Values: `"service":
-  "type": "ClusterIP"
-`,
+		Addons: []types.Addon{
+			{
+				Name:      "example-server",
+				Kind:      constants.AddonChart,
+				Enabled:   true,
+				Namespace: "default",
+				Chart: &types.ChartInfo{
+					Name:    "nginx",
+					Repo:    "https://charts.bitnami.com/bitnami",
+					Version: "15.1.1",
+					Values:  values,
+				},
 			},
 		},
-	},
+	}
+
+	return components
 }

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -124,7 +124,7 @@ func getAddons(components *types.Components) ([]v1alpha1.AddonSpec, error) {
 
 	for _, addon := range components.Addons {
 		if addon.Kind == constants.AddonChart {
-			addons = append(addons, v1alpha1.AddonSpec{
+			spec := v1alpha1.AddonSpec{
 				Name:      addon.Name,
 				Kind:      addon.Kind,
 				Enabled:   addon.Enabled,
@@ -134,9 +134,14 @@ func getAddons(components *types.Components) ([]v1alpha1.AddonSpec, error) {
 					Repo:    addon.Chart.Repo,
 					Version: addon.Chart.Version,
 					Set:     addon.Chart.Set,
-					Values:  addon.Chart.Values,
 				},
-			})
+			}
+			var err error
+			spec.Chart.Values, err = yamlValues(addon.Chart.Values)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert chart values to yaml: %w", err)
+			}
+			addons = append(addons, spec)
 		} else if addon.Kind == constants.AddonManifest {
 			addons = append(addons, v1alpha1.AddonSpec{
 				Name:      addon.Name,

--- a/pkg/types/blueprint.go
+++ b/pkg/types/blueprint.go
@@ -234,7 +234,7 @@ type ChartInfo struct {
 	Repo    string                        `yaml:"repo"`
 	Version string                        `yaml:"version"`
 	Set     map[string]intstr.IntOrString `yaml:"set,omitempty"`
-	Values  string                        `yaml:"values,omitempty"`
+	Values  dig.Mapping                   `yaml:"values,omitempty"`
 }
 
 // Validate checks the ChartInfo structure and its children


### PR DESCRIPTION
https://mirantis.jira.com/browse/BOP-281

## What this does
Change the helm values so that they are valid yaml in the blueprint

## Testing

The init command will now generate a blueprint with yaml for the helm values

```
nneisen:~/code/boundless-cli (BOP-281-helm-values-as-yaml): bctl init --kind
apiVersion: boundless.mirantis.com/v1alpha1
kind: Blueprint
metadata:
  name: boundless-cluster
spec:
  kubernetes:
    provider: kind
  components:
    core:
      ingress:
        enabled: true
        provider: ingress-nginx
        config:
          controller:
            service:
              nodePorts:
                http: 30000
                https: 30001
              type: NodePort
    addons:
    - name: example-server
      kind: chart
      enabled: true
      namespace: default
      chart:
        name: nginx
        repo: https://charts.bitnami.com/bitnami
        version: 15.1.1
        values:
          service:
            type: ClusterIP
```

Using this, create a cluster and look at the services created.
```
nneisen:~/code/boundless-cli (BOP-281-helm-values-as-yaml): kc get services -A
NAMESPACE          NAME                                                    TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
boundless-system   boundless-operator-controller-manager-metrics-service   ClusterIP   10.96.251.210   <none>        8443/TCP                     4m45s
boundless-system   cert-manager                                            ClusterIP   10.96.230.7     <none>        9402/TCP                     4m13s
boundless-system   cert-manager-webhook                                    ClusterIP   10.96.73.112    <none>        443/TCP                      4m13s
boundless-system   ingress-nginx-controller                                NodePort    10.96.91.6      <none>        80:30000/TCP,443:30001/TCP   2m
boundless-system   ingress-nginx-controller-admission                      ClusterIP   10.96.140.128   <none>        443/TCP                      2m
default            kubernetes                                              ClusterIP   10.96.0.1       <none>        443/TCP                      5m9s
default            nginx                                                   ClusterIP   10.96.5.150     <none>        80/TCP                       2m1s
kube-system        kube-dns                                                ClusterIP   10.96.0.10      <none>        53/UDP,53/TCP,9153/TCP       5m7s
```

Create the same cluster without the ingress values defining the service type and see that the nginx service is not the ClusterIP type.
```
nneisen:~/code/boundless-cli (BOP-281-helm-values-as-yaml): kc get services -A
NAMESPACE          NAME                                                    TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
boundless-system   boundless-operator-controller-manager-metrics-service   ClusterIP      10.96.175.68    <none>        8443/TCP                     3m36s
boundless-system   cert-manager                                            ClusterIP      10.96.172.124   <none>        9402/TCP                     3m3s
boundless-system   cert-manager-webhook                                    ClusterIP      10.96.82.82     <none>        443/TCP                      3m3s
boundless-system   ingress-nginx-controller                                NodePort       10.96.9.112     <none>        80:30000/TCP,443:30001/TCP   52s
boundless-system   ingress-nginx-controller-admission                      ClusterIP      10.96.125.213   <none>        443/TCP                      52s
default            kubernetes                                              ClusterIP      10.96.0.1       <none>        443/TCP                      4m
default            nginx                                                   LoadBalancer   10.96.206.154   <pending>     80:31183/TCP                 24s
kube-system        kube-dns                                                ClusterIP      10.96.0.10      <none>        53/UDP,53/TCP,9153/TCP       3m58s
```