### PR TITLE
[BOP-281] Default helm to use a yaml string

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -71,8 +71,8 @@ var defaultComponents = types.Components{
 				Name:    "nginx",
 				Repo:    "https://charts.bitnami.com/bitnami",
 				Version: "15.1.1",
-				Values: `"service":
-  "type": "ClusterIP"
+				Values: `service:
+  type: ClusterIP
 `,
 			},
 		},


### PR DESCRIPTION
https://mirantis.jira.com/browse/BOP-281

## What this does
Helm values can be defined as either a string of yaml or individual json strings(?). This changes the default so that it matches the other formats in a blueprint.

This doesn't fix the original issue of the ticket but I think it is a good change to have in for GA.

## How to test this
Create the default blueprint and see that it now uses a yaml string for the helm values
```
bctl init

apiVersion: boundless.mirantis.com/v1alpha1
kind: Blueprint
metadata:
  name: k0s-cluster
spec:
  kubernetes:
    provider: k0s
    version: 1.29.1+k0s.1
    infra:
      hosts:
      - ssh:
          address: 10.0.0.1
          keyPath: ""
          port: 22
          user: root
        role: controller
      - ssh:
          address: 10.0.0.2
          keyPath: ""
          port: 22
          user: root
        role: worker
  components:
    addons:
    - name: example-server
      kind: chart
      enabled: true
      namespace: default
      chart:
        name: nginx
        repo: https://charts.bitnami.com/bitnami
        version: 15.1.1
        values: |
          service:
            type: ClusterIP
```

Apply the blueprint and see that the values still create a service as a ClusterIP
```
nneisen:~/code/boundless-cli (BOP-281): kc get services -A
NAMESPACE          NAME                                                    TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                  AGE
boundless-system   boundless-operator-controller-manager-metrics-service   ClusterIP   10.109.208.114   <none>        8443/TCP                 7m57s
boundless-system   cert-manager                                            ClusterIP   10.104.166.220   <none>        9402/TCP                 7m51s
boundless-system   cert-manager-webhook                                    ClusterIP   10.100.66.152    <none>        443/TCP                  7m51s
default            kubernetes                                              ClusterIP   10.96.0.1        <none>        443/TCP                  8m40s
default            nginx                                                   ClusterIP   10.109.90.87     <none>        80/TCP                   6m48s
kube-system        kube-dns                                                ClusterIP   10.96.0.10       <none>        53/UDP,53/TCP,9153/TCP   8m32s
kube-system        metrics-server                                          ClusterIP   10.96.189.91     <none>        443/TCP                  8m27s
```

Comment out the values section and recreate the cluster. The services will be created this time as a LoadBalancer
```
nneisen:~/code/boundless-cli (BOP-281): kc get services -A
NAMESPACE          NAME                                                    TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                  AGE
boundless-system   boundless-operator-controller-manager-metrics-service   ClusterIP      10.109.208.114   <none>        8443/TCP                 74s
boundless-system   cert-manager                                            ClusterIP      10.104.166.220   <none>        9402/TCP                 68s
boundless-system   cert-manager-webhook                                    ClusterIP      10.100.66.152    <none>        443/TCP                  68s
default            kubernetes                                              ClusterIP      10.96.0.1        <none>        443/TCP                  117s
default            nginx                                                   LoadBalancer   10.109.90.87     <pending>     80:31528/TCP             5s
kube-system        kube-dns                                                ClusterIP      10.96.0.10       <none>        53/UDP,53/TCP,9153/TCP   109s
kube-system        metrics-server                                          ClusterIP      10.96.189.91     <none>        443/TCP                  104s
```

Run the blueprint through kubectl to show that it is still kubectl compliant (it actually isn't. You need to remove the spec.kubernetes section)
```
nneisen:~/code/boundless-cli (BOP-281): kubectl apply -f blueprint.yaml 
blueprint.boundless.mirantis.com/k0s-cluster configured
```