### PR TITLE
Added controller+worker k0s role

### DIFF
--- a/pkg/types/common.go
+++ b/pkg/types/common.go
@@ -25,7 +25,7 @@ type Host struct {
 	Role      string     `yaml:"role"`
 }
 
-var nodeRoles = []string{"single", "controller", "worker"}
+var nodeRoles = []string{"single", "controller", "worker", "controller+worker"}
 
 // Validate checks the Host structure and its children
 func (h *Host) Validate() error {


### PR DESCRIPTION
MKE runs managers as `controller+worker` k0s nodes, but bctl is missing this role in the validation list. This PR fixes it

Tested it manually by compiling bctl and running `bctl apply` with one of the nodes having `controller+worker` as the role