### PR TITLE
[BOP-324] Allow upgrading of localhost k0s provider

### DIFF
--- a/pkg/utils/exec.go
+++ b/pkg/utils/exec.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"os"
 	"os/exec"
+	"strings"
+	"unicode"
 )
 
 // ExecCommand executes a command and returns an error if it fails.
@@ -27,4 +29,21 @@ func ExecCommandQuietly(name string, args ...string) error {
 		return err
 	}
 	return nil
+}
+
+func ExecCommandWithReturn(name string) (string, error) {
+	cmd := exec.Command("sh", "-c", name)
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	// clean the output of non-printable characters
+	cleanStdOut := strings.TrimFunc(string(out), func(r rune) bool {
+		return !unicode.IsGraphic(r)
+	})
+
+	return cleanStdOut, nil
 }


### PR DESCRIPTION
### Description
Address [BOP-324](https://mirantis.jira.com/browse/BOP-324) . When working on the original issue ( https://mirantis.jira.com/browse/BOP-255) I missed some options I wasn't aware of for k0s node roles. This PR allows version upgrade to work for localhost, and also for nodes with role `controller+workers`

### Testing

```
ubuntu@ip-172-31-19-4:~$ kubectl get node
NAME             STATUS   ROLES           AGE    VERSION
ip-172-31-19-4   Ready    control-plane   158m   v1.28.4+k0s
ubuntu@ip-172-31-19-4:~$ cat blueprint-k0s-local.yaml
apiVersion: bctl.mirantis.com/v1alpha1
kind: Blueprint
metadata:
  name: k0s-example
spec:
  kubernetes:
    provider: k0s
    version: 1.28.4+k0s.0
    infra:
      hosts:
      - localhost:
          enabled: true
        role: single
  components:
    addons:
      - name: example-server
        kind: chart
        enabled: true
        namespace: default
        chart:
          name: nginx
          repo: https://charts.bitnami.com/bitnami
          version: 15.1.1
          values: |
            service:
              type: ClusterIP
```

Then changing the version to `1.28.5+k0s.0` and running `update` works:

```
ubuntu@ip-172-31-19-4:~$ ~/bctl update -f blueprint-k0s-local.yaml
INF out is v1.28.4+k0s.0
INF New provider version successfully validated
INF Updating provider

⠀⣿⣿⡇⠀⠀⢀⣴⣾⣿⠟⠁⢸⣿⣿⣿⣿⣿⣿⣿⡿⠛⠁⠀⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀█████████ █████████ ███
⠀⣿⣿⡇⣠⣶⣿⡿⠋⠀⠀⠀⢸⣿⡇⠀⠀⠀⣠⠀⠀⢀⣠⡆⢸⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀███          ███    ███
⠀⣿⣿⣿⣿⣟⠋⠀⠀⠀⠀⠀⢸⣿⡇⠀⢰⣾⣿⠀⠀⣿⣿⡇⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀███          ███    ███
⠀⣿⣿⡏⠻⣿⣷⣤⡀⠀⠀⠀⠸⠛⠁⠀⠸⠋⠁⠀⠀⣿⣿⡇⠈⠉⠉⠉⠉⠉⠉⠉⠉⢹⣿⣿⠀███          ███    ███
⠀⣿⣿⡇⠀⠀⠙⢿⣿⣦⣀⠀⠀⠀⣠⣶⣶⣶⣶⣶⣶⣿⣿⡇⢰⣶⣶⣶⣶⣶⣶⣶⣶⣾⣿⣿⠀█████████    ███    ██████████
k0sctl v0.17.4 Copyright 2023, k0sctl authors.
Anonymized telemetry of usage will be sent to the authors.
By continuing to use k0sctl you agree to these terms:
https://k0sproject.io/licenses/eula
INFO ==> Running phase: Connect to hosts
INFO [local] localhost: connected
INFO ==> Running phase: Detect host operating systems
INFO [local] localhost: is running Ubuntu 20.04.6 LTS
INFO ==> Running phase: Acquire exclusive host lock
INFO ==> Running phase: Prepare hosts
INFO ==> Running phase: Gather host facts
INFO [local] localhost: using ip-172-31-19-4 as hostname
INFO [local] localhost: discovered ens5 as private interface
INFO [local] localhost: discovered 172.31.19.4 as private address
INFO ==> Running phase: Validate hosts
INFO ==> Running phase: Gather k0s facts
INFO [local] localhost: found existing configuration
INFO [local] localhost: is running k0s single version v1.28.4+k0s.0
WARN [local] localhost: k0s will be upgraded
INFO ==> Running phase: Validate facts
INFO ==> Running phase: Download k0s on hosts
INFO [local] localhost: downloading k0s v1.28.5+k0s.0
INFO [local] localhost: validating configuration
INFO ==> Running phase: Upgrade controllers
INFO [local] localhost: starting upgrade
INFO [local] localhost: waiting for the k0s service to start
WARN [local] localhost: skipping scheduler and system pod checks because --no-wait given
INFO ==> Running phase: Release exclusive host lock
INFO ==> Running phase: Disconnect from hosts
INFO ==> Finished in 17s
INFO k0s cluster version v1.28.5+k0s.0 is now installed
INFO Tip: To access the cluster you can now fetch the admin kubeconfig using:
INFO      k0sctl kubeconfig
INF Applying Boundless Operator resources
INF Applying Blueprint
```

```
ubuntu@ip-172-31-19-4:~$ kubectl get node
NAME             STATUS   ROLES           AGE    VERSION
ip-172-31-19-4   Ready    control-plane   160m   v1.28.5+k0s
```




