### PR TITLE
BOP-368 Fix an issue where new kind cluster name is a substring of an existing cluster

### DIFF
--- a/pkg/distro/kind.go
+++ b/pkg/distro/kind.go
@@ -75,7 +75,7 @@ func (k *Kind) SetupClient() error {
 
 // Exists checks if kind exists
 func (k *Kind) Exists() (bool, error) {
-	output, err := utils.ExecCommandWithReturn(fmt.Sprintf("kind get clusters -q | grep %s", k.name))
+	err := utils.ExecCommandQuietly("bash", "-c", fmt.Sprintf("kind get clusters -q | grep -x %s", k.name))
 	if err != nil && strings.Contains(err.Error(), "exit status 1") {
 		return false, nil
 	}
@@ -83,18 +83,7 @@ func (k *Kind) Exists() (bool, error) {
 		return false, err
 	}
 
-	lines, err := utils.ReadLines(strings.NewReader(output))
-	if err != nil {
-		return false, err
-	}
-
-	for _, line := range lines {
-		if line == k.name {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return true, nil
 }
 
 // Reset deletes the kind cluster

--- a/pkg/utils/exec.go
+++ b/pkg/utils/exec.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"bufio"
-	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -49,17 +47,4 @@ func ExecCommandWithReturn(name string) (string, error) {
 	})
 
 	return cleanStdOut, nil
-}
-
-// ReadLines reads lines from an io.Reader and returns them as a slice of strings.
-func ReadLines(r io.Reader) ([]string, error) {
-	var lines []string
-	s := bufio.NewScanner(r)
-	for s.Scan() {
-		lines = append(lines, s.Text())
-	}
-	if err := s.Err(); err != nil {
-		return nil, err
-	}
-	return lines, nil
 }


### PR DESCRIPTION
Jira: https://mirantis.jira.com/browse/BOP-368

### Description

Fixes an issue where if a user tries to create a new `kind` based cluster with a name which is a substring of an existing cluster using `bctl apply`, it will fail.
For example, if a cluster with name `test-cluster-new` already exists, and user try to create a cluster with name `test-cluster`, this will fail with following error:
```
INF Applying blueprint kind1.yaml
INF Cluster "test-cluster" already exists
Error: unable to load kubeconfig from "/Users/rsingh/.kube/config": context "kind-test-cluster" does not exist
```

This PR fixes this issue.

### Testing

#### Manual Testing

1. Create to `kind` clusters with following names: `test-cluster-1` and `test-cluster-2`
```
apiVersion: boundless.mirantis.com/v1alpha1
kind: Blueprint
metadata:
  name: test-cluster-1
spec:
  kubernetes:
    provider: kind
  components:
    addons: []
```
```
apiVersion: boundless.mirantis.com/v1alpha1
kind: Blueprint
metadata:
  name: test-cluster-2
spec:
  kubernetes:
    provider: kind
  components:
    addons: []
```

```
kind get clusters
test-cluster-1
test-cluster-2
```
2. Try to create a cluster with name `test-cluster`:
```
❯ ./bin/bctl apply -f kind1.yaml
INF Applying blueprint at kind1.yaml
Creating cluster "test-cluster" ...
 ✓ Ensuring node image (kindest/node:v1.27.3) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
⠈⠑ Starting control-plane 🕹️
```
3. The cluster gets created successfully