### PR TITLE
[BP{-687] Remove the extra init log output

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
 	"github.com/mirantiscontainers/boundless-cli/pkg/commands"
@@ -13,7 +12,6 @@ func initCmd() *cobra.Command {
 		Use:   "init",
 		Short: "Creates a blueprint file template",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Info().Msg("Initializing blueprint")
 			return commands.Init(constants.ProviderK0s)
 		},
 	}


### PR DESCRIPTION
https://mirantis.jira.com/browse/BOP-687

An extra logging line was accidentally added to `bctl init` so that it no longer printed a valid default blueprint. This removes that line.

**Before**
```
INF Initializing blueprint   <---
apiVersion: boundless.mirantis.com/v1alpha1
kind: Blueprint
metadata:
  name: k0s-cluster
spec:
  kubernetes:
    provider: k0s
    infra:
      hosts:
      - ssh:
          address: 10.0.0.1
          keyPath: ""
          port: 22
          user: root
        role: controller
      - ssh:
          address: 10.0.0.2
          keyPath: ""
          port: 22
          user: root
        role: worker
  components:
    addons:
    - name: example-server
      kind: chart
      enabled: true
      dryRun: false
      namespace: default
      chart:
        name: nginx
        repo: https://charts.bitnami.com/bitnami
        version: 15.1.1
        values: |
          service:
            type: ClusterIP
```


**After**
```
apiVersion: boundless.mirantis.com/v1alpha1
kind: Blueprint
metadata:
  name: k0s-cluster
spec:
  kubernetes:
    provider: k0s
    infra:
      hosts:
      - ssh:
          address: 10.0.0.1
          keyPath: ""
          port: 22
          user: root
        role: controller
      - ssh:
          address: 10.0.0.2
          keyPath: ""
          port: 22
          user: root
        role: worker
  components:
    addons:
    - name: example-server
      kind: chart
      enabled: true
      dryRun: false
      namespace: default
      chart:
        name: nginx
        repo: https://charts.bitnami.com/bitnami
        version: 15.1.1
        values: |
          service:
            type: ClusterIP
```