### PR TITLE
[BOP-660] Add installFlags field for k0s hosts

### DIFF
--- a/pkg/types/common.go
+++ b/pkg/types/common.go
@@ -20,9 +20,10 @@ func (m *Metadata) Validate() error {
 }
 
 type Host struct {
-	SSH       *SSHHost   `yaml:"ssh,omitempty"`
-	LocalHost *LocalHost `yaml:"localhost,omitempty"`
-	Role      string     `yaml:"role"`
+	SSH          *SSHHost   `yaml:"ssh,omitempty"`
+	LocalHost    *LocalHost `yaml:"localhost,omitempty"`
+	Role         string     `yaml:"role"`
+	InstallFlags []string   `yaml:"installFlags,omitempty"`
 }
 
 var nodeRoles = []string{"single", "controller", "worker", "controller+worker"}


### PR DESCRIPTION
## What is this?

This PR adds an `installFlags` section to the `Host` spec used for k0s hosts. This aligns with the k0sctl host configuration spec: [k0s - Configuration File](https://github.com/k0sproject/k0sctl?tab=readme-ov-file#configuration-file).

The reason for this change is that accessing metrics for some system components, namely etcd, is best done by enabling the metrics scraper component on k0s controller nodes. The only way to do this is with an install time flag. More info: [k0s - System Monitoring](https://docs.k0sproject.io/v1.29.3+k0s.0/system-monitoring/)

## Manual test with `--enable-metrics-scraper`

1. Add flag to blueprint.yaml
```
apiVersion: blueprint.mirantis.com/v1alpha1
kind: Blueprint
metadata:
  name: k0s-cluster
spec:
  kubernetes:
    provider: k0s
    infra:
      hosts:
      - ssh:
          address: ****
          keyPath: ****
          port: 22
          user: ****
        role: single
        installFlags:
        - --enable-metrics-scraper
```
2. Deploy
`bctl apply`
3. Check for metrics-scraper component
```
% kubectl --kubeconfig kc get -nk0s-system pods
NAME                               READY   STATUS    RESTARTS   AGE
k0s-pushgateway-86bd768578-wlx7c   1/1     Running   0          106s

```