### PR TITLE
[BOP-838] Refresh existing clusters on apply

### DIFF
--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -35,11 +35,14 @@ func Apply(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig, operatorUri s
 			return fmt.Errorf("cluster %q already exists", blueprint.Metadata.Name)
 		}
 	}
-	if exists {
-		log.Info().Msgf("Cluster %q already exists", blueprint.Metadata.Name)
-	} else {
+	if !exists {
 		if err := provider.Install(); err != nil {
 			return fmt.Errorf("failed to install cluster: %w", err)
+		}
+	} else {
+		log.Info().Msgf("Cluster %q already exists", blueprint.Metadata.Name)
+		if err = provider.Refresh(); err != nil {
+			return fmt.Errorf("failed to refresh cluster: %w", err)
 		}
 	}
 

--- a/pkg/distro/existing.go
+++ b/pkg/distro/existing.go
@@ -54,9 +54,15 @@ func (e *Existing) WaitForPods() error {
 	return nil
 }
 
-// Install installs the existing cluster
+// Install is a noop for existing cluster
 func (e *Existing) Install() error {
 	log.Debug().Msgf("Nothing done to install an unmanaged existing cluster")
+	return nil
+}
+
+// Refresh is a noop for existing cluster
+func (e *Existing) Refresh() error {
+	log.Debug().Msgf("Nothing done to refresh an unmanaged existing cluster")
 	return nil
 }
 

--- a/pkg/distro/k0s.go
+++ b/pkg/distro/k0s.go
@@ -63,6 +63,18 @@ func (k *K0s) Install() error {
 	return nil
 }
 
+// Refresh reapplies k0sctl config with the current version of blueprint
+func (k *K0s) Refresh() error {
+	kubeConfigPath := k.kubeConfig.GetConfigPath()
+	log.Debug().Msgf("Refreshing k0s cluster %q with kubeConfig at: %s", k.name, kubeConfigPath)
+
+	if err := utils.ExecCommand(fmt.Sprintf("k0sctl apply --config %s --no-wait", k.k0sConfig)); err != nil {
+		return fmt.Errorf("k0sctl apply failed: %w", err)
+	}
+
+	return nil
+}
+
 // Update updates k0s using k0sctl
 func (k *K0s) Upgrade() error {
 	if err := utils.ExecCommand(fmt.Sprintf("k0sctl apply --config %s --no-wait", k.k0sConfig)); err != nil {

--- a/pkg/distro/kind.go
+++ b/pkg/distro/kind.go
@@ -59,6 +59,11 @@ func (k *Kind) Install() error {
 	return nil
 }
 
+func (k *Kind) Refresh() error {
+	log.Debug().Msg("Kind cluster does not support refresh; to change the cluster config, delete and recreate it")
+	return nil
+}
+
 func (k *Kind) Upgrade() error {
 	return nil
 }

--- a/pkg/distro/provider.go
+++ b/pkg/distro/provider.go
@@ -11,6 +11,7 @@ import (
 // Provider is the interface for a distro provider
 type Provider interface {
 	Install() error
+	Refresh() error
 	Upgrade() error
 	SetupClient() error
 	Exists() (bool, error)


### PR DESCRIPTION
# Description

bctl doesn't support changing cluster configuration of existing clusters. As a result, in case of k0s, users cannot add new nodes even though k0sctl supports such a functionality. 
Additionally, `kuberenetes.config` section is only applied on install making it impossible to change cluster configuration after the first `bctl apply`

This PR adds a `Refresh()` method to the provider interface. The method is supposed to refresh the cluster configuration on every `bctl apply` based on the current version of the blueprint.

- For k0s, it runs `k0sctl apply`
- For kind and unmanaged clusters, it has no effect since these clusters do not support refreshing.

# Testing

1. Create a blueprint, run `bctl apply`
2. Add a node to the blueprint, run `bctl apply`
3. The new node must appear on the node list `kubectl get nodes`

