### PR TITLE
[BOP-958] Don't exit immediately while waiting for resources

### DIFF
--- a/pkg/k8s/wait.go
+++ b/pkg/k8s/wait.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -32,7 +31,8 @@ func waitForPods(ctx context.Context, clientset kubernetes.Interface, namepsace 
 	return wait.PollUntilContextCancel(timeoutCtx, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 		pods, err := clientset.CoreV1().Pods(namepsace).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return false, fmt.Errorf("failed to list pods: %v", err)
+			log.Warn().Msgf("failed to list pods: %s", err)
+			return false, nil
 		}
 
 		if len(pods.Items) == 0 {
@@ -69,7 +69,8 @@ func waitForNodes(ctx context.Context, clientset kubernetes.Interface) error {
 		// wait for node to be ready
 		nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return false, fmt.Errorf("failed to list nodes: %v", err)
+			log.Warn().Msgf("failed to list nodes: %s", err)
+			return false, nil
 		}
 
 		if len(nodes.Items) == 0 {


### PR DESCRIPTION
When `k0sctl apply` restarts the k0s service, API server may take a few seconds to spin up. While it's starting, "Waiting for nodes to be ready" step fails with the `connection refused` error instead of waiting. We should not immediately exit, but wait and retry.

```
<...>
?level=info msg="[ssh] 18.226.4.185:22: restarting k0s service"
Ilevel=info msg="[ssh] 18.226.4.185:22: waiting for k0s service to start"
@level=info msg="==> Running phase: Release exclusive host lock"
:level=info msg="==> Running phase: Disconnect from hosts"
%level=info msg="==> Finished in 13s"
Dlevel=info msg="k0s cluster version v1.29.3+k0s.0 is now installed"
Zlevel=info msg="Tip: To access the cluster you can now fetch the admin kubeconfig using:"
(level=info msg="     k0sctl kubeconfig"
hA new version v0.18.1 of k0sctl is available: https://github.com/k0sproject/k0sctl/releases/tag/v0.18.1
3INF Waiting for nodes to be ready
�Error: failed to setup client: failed to wait for nodes: failed to list nodes: Get "https://18.226.4.185:6443/api/v1/nodes": dial tcp 18.226.4.185:6443: connect: connection refused
```