### PR TITLE
[BOP-1266] Rename boundless in logs to blueprint

### DIFF
--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -17,7 +17,7 @@ Reset the cluster to a clean state.
 
 For a cluster with k0s, this will remove traces of k0s from all the hosts.
 For a cluster with kind, it will delete the cluster (same as 'kind delete cluster <CLUSTER NAME>').
-For a cluster with an external Kubernetes provider, this will remove Boundless Operator and all associated resources.
+For a cluster with an external Kubernetes provider, this will remove Blueprint Operator and all associated resources.
 `,
 		Args:    cobra.NoArgs,
 		PreRunE: actions(loadBlueprint, loadKubeConfig),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	appName      = "bctl"
-	shortAppDesc = "A tool to manage boundless operator."
+	shortAppDesc = "A tool to manage blueprint operator."
 )
 
 var (

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -10,7 +10,7 @@ import (
 func upgradeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "upgrade",
-		Short:   "Upgrade boundless operator on the cluster",
+		Short:   "Upgrade blueprint operator on the cluster",
 		Args:    cobra.NoArgs,
 		PreRunE: actions(loadBlueprint, loadKubeConfig),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Apply installs the Boundless Operator and applies the components defined in the blueprint
+// Apply installs the Blueprint Operator and applies the components defined in the blueprint
 func Apply(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig) error {
 	// Determine the distro
 	provider, err := distro.GetProvider(blueprint, kubeConfig)
@@ -29,7 +29,7 @@ func Apply(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig) error {
 	}
 
 	// If we are working with an unsupported provider, we need to make sure it exists
-	// For other supported providers, we check whether boundless is already installed
+	// For other supported providers, we check whether blueprint is already installed
 	if provider.Type() == constants.ProviderExisting {
 		if !exists {
 			return fmt.Errorf("cluster %q already exists", blueprint.Metadata.Name)
@@ -59,13 +59,13 @@ func Apply(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig) error {
 		panic(err)
 	}
 
-	// For existing clusters, determine whether boundless is currently installed
+	// For existing clusters, determine whether blueprint is currently installed
 	installOperator := true
 	if exists {
 		_, err := k8sclient.AppsV1().Deployments(constants.NamespaceBlueprint).Get(context.TODO(), constants.BlueprintOperatorDeployment, metav1.GetOptions{})
 		if err != nil {
 			if !errors.IsNotFound(err) {
-				log.Warn().Msgf("Could not determine existing Boundless Operator installation: %s", err)
+				log.Warn().Msgf("Could not determine existing Blueprint Operator installation: %s", err)
 			}
 		} else {
 			// @todo: determine operator version
@@ -80,13 +80,13 @@ func Apply(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig) error {
 
 	// @todo: display the version of the operator
 	if installOperator {
-		log.Info().Msgf("Installing Boundless Operator")
-		log.Debug().Msgf("Installing Boundless Operator using manifest file: %s", blueprint.Spec.Version)
+		log.Info().Msgf("Installing Blueprint Operator")
+		log.Debug().Msgf("Installing Blueprint Operator using manifest file: %s", blueprint.Spec.Version)
 		if err = k8s.ApplyYaml(kubeConfig, uri); err != nil {
-			return fmt.Errorf("failed to install Boundless Operator: %w", err)
+			return fmt.Errorf("failed to install Blueprint Operator: %w", err)
 		}
 	} else {
-		log.Info().Msg("Boundless Operator already installed")
+		log.Info().Msg("Blueprint Operator already installed")
 	}
 
 	// Wait for the pods to be ready
@@ -95,13 +95,13 @@ func Apply(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig) error {
 	}
 
 	// install components
-	log.Info().Msgf("Applying Boundless Operator resource")
+	log.Info().Msgf("Applying Blueprint Operator resource")
 	err = components.ApplyBlueprint(kubeConfig, blueprint)
 	if err != nil {
 		return fmt.Errorf("failed to install components: %w", err)
 	}
 
-	log.Info().Msgf("Finished installing Boundless Operator")
+	log.Info().Msgf("Finished installing Blueprint Operator")
 
 	return nil
 }

--- a/pkg/commands/reset.go
+++ b/pkg/commands/reset.go
@@ -37,7 +37,7 @@ func Reset(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig, force bool) e
 	}
 
 	// Uninstall components
-	log.Info().Msgf("Reset Boundless Operator resources")
+	log.Info().Msgf("Reset Blueprint Operator resources")
 	err = components.RemoveComponents(provider.GetKubeConfig(), blueprint)
 	if err != nil {
 		return fmt.Errorf("failed to reset components: %w", err)
@@ -48,10 +48,10 @@ func Reset(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig, force bool) e
 		return fmt.Errorf("failed to determine operator URI: %w", err)
 	}
 
-	log.Info().Msgf("Uninstalling Boundless Operator")
-	log.Debug().Msgf("Uninstalling boundless operator using manifest file: %s", uri)
+	log.Info().Msgf("Uninstalling Blueprint Operator")
+	log.Debug().Msgf("Uninstalling blueprint operator using manifest file: %s", uri)
 	if err = k8s.DeleteYamlObjects(kubeConfig, uri); err != nil {
-		return fmt.Errorf("failed to uninstall Boundless Operator: %w", err)
+		return fmt.Errorf("failed to uninstall Blueprint Operator: %w", err)
 	}
 
 	// Reset the cluster

--- a/pkg/commands/status.go
+++ b/pkg/commands/status.go
@@ -26,7 +26,7 @@ const (
 	kubernetesInstanceLabel      = "app.kubernetes.io/instance"
 )
 
-// Status prints the status of the boundless operator and any installed addons
+// Status prints the status of the blueprint operator and any installed addons
 func Status(kubeConfig *k8s.KubeConfig) error {
 	k8sclient, err := k8s.GetClient(kubeConfig)
 	if err != nil {
@@ -36,7 +36,7 @@ func Status(kubeConfig *k8s.KubeConfig) error {
 	operatorDeployment, err := k8sclient.AppsV1().Deployments(constants.NamespaceBlueprint).Get(context.TODO(), constants.BlueprintOperatorDeployment, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			fmt.Println("No boundless operator installation detected")
+			fmt.Println("No blueprint operator installation detected")
 		} else {
 			panic(err)
 		}
@@ -107,7 +107,7 @@ func AddonSpecificStatus(kubeConfig *k8s.KubeConfig, providedAddonName string) e
 	}
 	fmt.Println("-------------------------------------------------------")
 
-	// lastly show any events created by boundless
+	// lastly show any events created by blueprint
 	// kubernetes events are relatively short-lived, so we can't rely on them always being here
 
 	var eventMsgs []string
@@ -124,12 +124,12 @@ func AddonSpecificStatus(kubeConfig *k8s.KubeConfig, providedAddonName string) e
 	}
 
 	if len(eventMsgs) > 0 {
-		fmt.Println("\nBOUNDLESS SYSTEM EVENTS")
+		fmt.Println("\nBLUEPRINT SYSTEM EVENTS")
 		for _, msg := range eventMsgs {
 			fmt.Printf("%s\n", msg)
 		}
 	} else {
-		fmt.Printf("No boundless system events for addon %s\n", providedAddonName)
+		fmt.Printf("No blueprint system events for addon %s\n", providedAddonName)
 	}
 
 	return nil

--- a/pkg/commands/update.go
+++ b/pkg/commands/update.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Update updates the Boundless Operator and applies the components defined in the blueprint
+// Update updates the Blueprint Operator and applies the components defined in the blueprint
 func Update(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig) error {
 	// Determine the distro
 	provider, err := distro.GetProvider(blueprint, kubeConfig)
@@ -34,11 +34,11 @@ func Update(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig) error {
 		}
 	}
 
-	log.Info().Msgf("Applying Boundless Operator resources")
+	log.Info().Msgf("Applying Blueprint Operator resources")
 	if err := components.ApplyBlueprint(kubeConfig, blueprint); err != nil {
 		return fmt.Errorf("failed to update components: %w", err)
 	}
 
-	log.Info().Msgf("Finished updating Boundless Operator")
+	log.Info().Msgf("Finished updating Blueprint Operator")
 	return nil
 }

--- a/pkg/commands/upgrade.go
+++ b/pkg/commands/upgrade.go
@@ -8,18 +8,18 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Upgrade upgrades the Boundless Operator
+// Upgrade upgrades the Blueprint Operator
 func Upgrade(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig) error {
 	uri, err := determineOperatorUri(blueprint.Spec.Version)
 	if err != nil {
 		return fmt.Errorf("failed to determine operator URI: %w", err)
 	}
 
-	log.Info().Msgf("Upgrading Boundless Operator using manifest file %q", uri)
+	log.Info().Msgf("Upgrading Blueprint Operator using manifest file %q", uri)
 	if err := k8s.ApplyYaml(kubeConfig, uri); err != nil {
-		return fmt.Errorf("failed to upgrade boundless operator: %w", err)
+		return fmt.Errorf("failed to upgrade blueprint operator: %w", err)
 	}
 
-	log.Info().Msgf("Finished updating Boundless Operator")
+	log.Info().Msgf("Finished updating Blueprint Operator")
 	return nil
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -3,10 +3,10 @@ package constants
 import "time"
 
 const (
-	// ManifestUrlLatest is the URL of the latest manifest YAML for the Boundless Operator
+	// ManifestUrlLatest is the URL of the latest manifest YAML for the Blueprint Operator
 	ManifestUrlLatest = "https://raw.githubusercontent.com/mirantiscontainers/boundless/main/deploy/static/boundless-operator.yaml"
 
-	// NamespaceBlueprint is the system namespace where the Boundless Operator and its components are installed
+	// NamespaceBlueprint is the system namespace where the Blueprint Operator and its components are installed
 	NamespaceBlueprint = "blueprint-system"
 
 	// DefaultBlueprintFileName represents the default blueprint filename.


### PR DESCRIPTION
https://mirantis.jira.com/browse/BOP-1266

Removes "boundless" from any logs. I also looked through the boundless-operator for anything referred to as "boundless" that was customer facing.

This only fixes logs. Boundless is still used throughout the code base for variable named and library references.