### PR TITLE
[NA] Change the public release name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,14 +51,14 @@ archives:
 
 # Used during a dev build without a git tag
 snapshot:
-  name_template: 'bctl-{{ .Version }}-{{.ShortCommit}}'
+  name_template: '{{ .Version }}-{{.ShortCommit}}'
 
 release:
   # release to the public repository
   github:
     owner: mirantiscontainers
     name: blueprint
-  name_template: "bctl-v{{.Version}}"
+  name_template: "v{{.Version}}"
 
 changelog:
   sort: asc


### PR DESCRIPTION
This changes the public release name so that the bctl binary and BOP manifest push to the same release name

Currently separate releases are created in the blueprint repo by each. `bctl-v<version>` and `v<version>`. This makes it so both the new version of bctl and bop manifest will pull be under the same location.