### PR TITLE
[BOP-1280] Wait for pods to be ready after bctl upgrade

### DIFF
--- a/pkg/commands/upgrade.go
+++ b/pkg/commands/upgrade.go
@@ -30,7 +30,7 @@ func Upgrade(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig) error {
 		return fmt.Errorf("failed to determine kubernetes provider: %w", err)
 	}
 	// Wait for the pods to be ready
-	if err := provider.WaitForods(); err != nil {
+	if err := provider.WaitForPods(); err != nil {
 		return fmt.Errorf("failed to wait for pods: %w", err)
 	}
 	return nil


### PR DESCRIPTION
This PR adds a wait for the blueprint pods after `bctl.Upgrade` is called, based on the kube distro.
This is similar to the `bctl.Apply` command