### PR TITLE
BOP-1609 support provisioning-only/operator-only

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -14,7 +14,7 @@ func applyCmd() *cobra.Command {
 		PreRunE: actions(loadBlueprint, loadKubeConfig),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info().Msgf("Applying blueprint at %s", blueprintFlag)
-			return commands.Apply(&blueprint, kubeConfig, false, false)
+			return commands.Apply(&blueprint, kubeConfig, false)
 		},
 	}
 

--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Apply installs the Blueprint Operator and applies the components defined in the blueprint
-func Apply(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig, providerInstallOnly bool, noRefresh bool) error {
+func Apply(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig, providerInstallOnly bool) error {
 	// Determine the distro
 	provider, err := distro.GetProvider(blueprint, kubeConfig)
 	if err != nil {
@@ -40,18 +40,15 @@ func Apply(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig, providerInsta
 			return fmt.Errorf("failed to install cluster: %w", err)
 
 		}
-		if providerInstallOnly {
-			return nil
-		}
 	} else {
 		log.Info().Msgf("Cluster %q already exists", blueprint.Metadata.Name)
-		if !noRefresh {
-			if err = provider.Refresh(); err != nil {
-				return fmt.Errorf("failed to refresh cluster: %w", err)
-			}
-		} else {
-			log.Warn().Msgf("skipping refresh")
+		if err = provider.Refresh(); err != nil {
+			return fmt.Errorf("failed to refresh cluster: %w", err)
 		}
+	}
+
+	if providerInstallOnly {
+		return nil
 	}
 
 	if err = kubeConfig.TryLoad(); err != nil {


### PR DESCRIPTION
Adds support for scenarios where:

1. The cluster needs to be provisioned without installing the blueprint operator
2. Installing the operator on a cluster that has already been provisioned and does not require a refresh

Is a prerequisite for supporting mke4 scenarios where the k8s provider/provisioner does not support desired network setup natively. Would enable bootstrapping up the desired network provider before installing the blueprint operator. This support is currently missing in boundless-operator (and hence in mke4).

Once the PR is approved and merged, corresponding changes to mkectl will be brought in after updating their vendoring to consume these changes.

Changes are opt-in and the current callers will be updated to maintain the default behavior.

Tested by changing the caller(mkectl) and installing CNI in-between the call that instantiate the cluster(i.e. installation of the k8s provider) and the calls that install the (boundless) operator. The resulting cluster passed CNCF conformance tests.