### PR TITLE
[No JIRA] Setup client before waiting for pods in upgrade

### DIFF
--- a/pkg/commands/upgrade.go
+++ b/pkg/commands/upgrade.go
@@ -29,6 +29,9 @@ func Upgrade(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to determine kubernetes provider: %w", err)
 	}
+	if err := provider.SetupClient(); err != nil {
+		return fmt.Errorf("failed to setup client: %w", err)
+	}
 	// Wait for the pods to be ready
 	if err := provider.WaitForPods(); err != nil {
 		return fmt.Errorf("failed to wait for pods: %w", err)


### PR DESCRIPTION
After https://github.com/MirantisContainers/blueprint-cli/commit/268e7a1386ddc2e521e6c324724538623daae347 was introduced, the bctl upgrade command panics.
This hot fix solves that issue by creating a client needed to wait for the pods