### PR TITLE
[BOP-1388] Update versioning to use semver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+include build/makefiles/vars.mk
 
 .PHONY: default
 default:  build
@@ -5,9 +6,6 @@ default:  build
 BIN_DIR := $(shell pwd)/bin
 
 # LDFLAGS
-VERSION := $(shell git tag --sort=committerdate | tail -1)
-COMMIT := $(shell git rev-parse HEAD)
-DATE := $(shell date -u '+%Y-%m-%d')
 LDFLAGS=-ldflags \
 				" \
 				-X github.com/mirantiscontainers/blueprint-cli/cmd.version=${VERSION} \

--- a/build/makefiles/vars.mk
+++ b/build/makefiles/vars.mk
@@ -1,0 +1,17 @@
+# The default naming convention for the operator is for a development image
+# on a developer's machine. This is so that devs don't have to remember to set
+# these values. CI will set vars so that the image is tagged correctly during
+# a CI build.
+COMMIT=$(shell git rev-parse --short HEAD)
+DATE=$(shell date -u '+%Y-%m-%d')
+
+# A basic dev version is by default to match images
+VERSION?=dev
+ifdef RELEASE_BUILD
+    VERSION=$(shell git tag -l "v*.*.*" --sort=-version:refname | head -n 1)
+endif
+ifdef MERGE_BUILD
+	# This will replace the last 2 '-' characters with '+' to make it a valid semver with build info
+	# Assumes that the version is in the format vX.Y.Z-<commit count>-<sha>
+    VERSION=$(shell git describe --tags --always | sed 's/\(.*\)-/\1+/' | sed 's/\(.*\)-/\1+/')
+endif

--- a/cmd/cmd_suite_test.go
+++ b/cmd/cmd_suite_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+	"sync"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cmd Suite")
+}
+
+// captureOutput is a helper function to capture stdout and stderr
+func captureOutput(f func()) string {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+		log.SetOutput(os.Stderr)
+	}()
+	os.Stdout = writer
+	os.Stderr = writer
+	log.SetOutput(writer)
+	out := make(chan string)
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+	go func() {
+		var buf bytes.Buffer
+		wg.Done()
+		io.Copy(&buf, reader)
+		out <- buf.String()
+	}()
+	wg.Wait()
+	f()
+	writer.Close()
+	return <-out
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,52 +3,38 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/mirantiscontainers/blueprint-cli/pkg/color"
 	"github.com/spf13/cobra"
 )
 
 var (
 	version, commit, date = "", "", "" // These are always injected at build time
+
+	// verbose flag
+	verbose bool
 )
 
+// versionCmd creates the version command
 func versionCmd() *cobra.Command {
-	var short bool
-
-	command := cobra.Command{
+	cmd := cobra.Command{
 		Use:   "version",
 		Short: "Print version/build info",
 		Long:  "Print version/build information",
-		Run: func(cmd *cobra.Command, args []string) {
-			printVersion(short)
-		},
+		RunE:  runVersion,
 	}
 
-	command.PersistentFlags().BoolVarP(&short, "short", "s", false, "Prints bctl version info in short format")
+	flags := cmd.Flags()
+	flags.BoolVarP(&verbose, "verbose", "v", false, "Print more detailed version information")
 
-	return &command
+	return &cmd
 }
 
-func printVersion(short bool) {
-	const fmat = "%-20s %s\n"
-
-	var outputColor color.Paint
-
-	if short {
-		outputColor = -1
-	} else {
-		outputColor = color.Cyan
+// runVersion prints the version information
+func runVersion(cmd *cobra.Command, args []string) error {
+	fmt.Printf("Version: %s\n", version)
+	if verbose {
+		fmt.Printf("Commit: %s\n", commit)
+		fmt.Printf("Date: %s\n", date)
 	}
-	printTuple(fmat, "Version", version, outputColor)
-	printTuple(fmat, "Commit", commit, outputColor)
-	printTuple(fmat, "Date", date, outputColor)
-}
 
-func printTuple(fmat, section, value string, outputColor color.Paint) {
-	if value != "" {
-		if outputColor != -1 {
-			fmt.Fprintf(out, fmat, color.Colorize(section+":", outputColor), value)
-			return
-		}
-		fmt.Fprintf(out, fmat, section, value)
-	}
+	return nil
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Version Command", func() {
+	// There's not a great way to unit test dev vs merge vs release versions
+	// It's more of an e2e test
+	// We can atleast check the output format
+	Context("version outputs", func() {
+		It("default output should print just the version", func() {
+			output := captureOutput(func() {
+				// Setup the command
+				cmd := versionCmd()
+
+				// Call the command
+				err := runVersion(cmd, []string{})
+				Expect(err).To(BeNil())
+			})
+
+			Expect(output).To(Equal(fmt.Sprintf("Version: %s\n", version)))
+		})
+
+		It("verbose output should print version, date, and commit on separate lines", func() {
+			output := captureOutput(func() {
+				// Setup the command
+				cmd := versionCmd()
+				cmd.Flags().Set("verbose", "true")
+
+				// Call the command
+				err := runVersion(cmd, []string{})
+				Expect(err).To(BeNil())
+			})
+
+			Expect(output).To(Equal(fmt.Sprintf("Version: %s\nCommit: %s\nDate: %s\n", version, commit, date)))
+		})
+	})
+})


### PR DESCRIPTION
https://mirantis.jira.com/browse/BOP-1388

Adds the standard semver scripts used across the MKE4 projects

## Manual testing
Local dev build:
```
nneisen: code/blueprint-cli - (BOP-1388) > make  build && bctl version -v                
Version: dev
Commit: c62d606
Date: 2024-12-12
```

Merge build:
```
nneisen: code/blueprint-cli - (BOP-1388) > MERGE_BUILD=1 make  build && bctl version -v           
Version: dev+1+gc62d606
Commit: c62d606
Date: 2024-12-12
```

Release build:
```
nneisen: code/blueprint-cli - (BOP-1388) > RELEASE_BUILD=1 make  build && bctl version -v         
Version: v1.0.16
Commit: c62d606
Date: 2024-12-12
```

## Automatic testing
Unit tests were also added

## Notes
This PR does not add changes to use these values in CI