### PR TITLE
[BOP-1745] Configurable image registry

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -14,13 +14,14 @@ func applyCmd() *cobra.Command {
 		PreRunE: actions(loadBlueprint, loadKubeConfig),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info().Msgf("Applying blueprint at %s", blueprintFlag)
-			return commands.Apply(&blueprint, kubeConfig, false)
+			return commands.Apply(&blueprint, kubeConfig, false, imageRegistry)
 		},
 	}
 
 	flags := cmd.Flags()
 	addBlueprintFileFlags(flags)
 	addKubeFlags(flags)
+	addImageRegistryFlag(flags)
 
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -153,7 +153,7 @@ func addBlueprintFileFlags(flags *pflag.FlagSet) {
 }
 
 func addImageRegistryFlag(flags *pflag.FlagSet) {
-	flags.StringVarP(&imageRegistry, "image-registry", "", constants.MirantisImageRegistry, "Image registry to pull BOP images from")
+	flags.StringVarP(&imageRegistry, "image-registry", "", "", "Image registry to pull BOP images from")
 }
 
 func addKubeFlags(flags *pflag.FlagSet) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ var (
 	pFlags        *PersistenceFlags
 	blueprintFlag string
 	force         bool
+	imageRegistry string
 
 	blueprint  types.Blueprint
 	kubeConfig *k8s.KubeConfig
@@ -149,6 +150,10 @@ func addForceFlag(flags *pflag.FlagSet) {
 
 func addBlueprintFileFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&blueprintFlag, "file", "f", constants.DefaultBlueprintFileName, "Path to the blueprint file")
+}
+
+func addImageRegistryFlag(flags *pflag.FlagSet) {
+	flags.StringVarP(&imageRegistry, "image-registry", "", constants.MirantisImageRegistry, "Image registry to pull BOP images from")
 }
 
 func addKubeFlags(flags *pflag.FlagSet) {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -15,13 +15,14 @@ func upgradeCmd() *cobra.Command {
 		PreRunE: actions(loadBlueprint, loadKubeConfig),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info().Msgf("Upgrading blueprint at %s", blueprintFlag)
-			return commands.Upgrade(&blueprint, kubeConfig)
+			return commands.Upgrade(&blueprint, kubeConfig, imageRegistry)
 		},
 	}
 
 	flags := cmd.Flags()
 	addBlueprintFileFlags(flags)
 	addKubeFlags(flags)
+	addImageRegistryFlag(flags)
 
 	return cmd
 }

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"os"
 	"strings"
 
@@ -129,5 +130,18 @@ var _ = Describe("Commands", func() {
 			Entry("with remote URI", remoteKey),
 			Entry("with local URI", localKey),
 		)
+	})
+
+	It("detect image registry", func() {
+		detected, err := detectDeployedRegistry([]corev1.Container{
+			{
+				Image: "ghcr.io/mirantiscontainers/kube-rbac-proxy:v1.0.0",
+			},
+			{
+				Image: "ghcr.io/mirantiscontainers/blueprint-operator:v1.0.0",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(detected).To(Equal("ghcr.io/mirantiscontainers"))
 	})
 })

--- a/pkg/commands/upgrade.go
+++ b/pkg/commands/upgrade.go
@@ -1,14 +1,17 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/rs/zerolog/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/mirantiscontainers/blueprint-cli/pkg/constants"
 	"github.com/mirantiscontainers/blueprint-cli/pkg/distro"
 	"github.com/mirantiscontainers/blueprint-cli/pkg/k8s"
 	"github.com/mirantiscontainers/blueprint-cli/pkg/types"
@@ -16,6 +19,34 @@ import (
 
 // Upgrade upgrades the Blueprint Operator
 func Upgrade(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig, imageRegistry string) error {
+	var client kubernetes.Interface
+	var err error
+
+	if client, err = k8s.GetClient(kubeConfig); err != nil {
+		return fmt.Errorf("failed to get kubernetes client: %q", err)
+	}
+
+	bopDeployment, err := client.AppsV1().Deployments(constants.NamespaceBlueprint).Get(context.TODO(), constants.BlueprintOperatorDeployment, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get existing Blueprint Operator deployment: %w", err)
+	}
+
+	deployedRegistry, err := detectDeployedRegistry(bopDeployment.Spec.Template.Spec.Containers)
+	if err != nil {
+		return fmt.Errorf("failed to detect image registry of the deployed Blueprint Operator: %w", err)
+	}
+
+	if imageRegistry == "" {
+		imageRegistry = deployedRegistry
+	} else if deployedRegistry != imageRegistry {
+		return fmt.Errorf(
+			"image registry %s does not match the deployed blueprint operator image registry %s; "+
+				"use --image-registry flag to upgrade with the same registry, "+
+				"or run `bctl apply --image-registry` to change the image registry of the deployed BOP before upgrading",
+			imageRegistry, deployedRegistry,
+		)
+	}
+
 	uri, err := determineOperatorUri(blueprint.Spec.Version)
 	if err != nil {
 		return fmt.Errorf("failed to determine operator URI: %w", err)
@@ -30,12 +61,8 @@ func Upgrade(blueprint *types.Blueprint, kubeConfig *k8s.KubeConfig, imageRegist
 		defer os.Remove(strings.TrimPrefix(uri, "file://"))
 	}
 
-	var client kubernetes.Interface
 	var dynamicClient dynamic.Interface
 
-	if client, err = k8s.GetClient(kubeConfig); err != nil {
-		return fmt.Errorf("failed to get kubernetes client: %q", err)
-	}
 	if dynamicClient, err = k8s.GetDynamicClient(kubeConfig); err != nil {
 		return fmt.Errorf("failed to get kubernetes dynamic client: %q", err)
 	}

--- a/pkg/commands/utils.go
+++ b/pkg/commands/utils.go
@@ -1,8 +1,12 @@
 package commands
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 
@@ -64,4 +68,93 @@ func parseUri(version string) (string, error) {
 		return "", fmt.Errorf("failed to parse uri: %w", err)
 	}
 	return uri.String(), nil
+}
+
+// setImageRegistry replaces the image registry in the BOP manifest with the provided one
+// if the supplied URI points to remote file, it is downloaded first;
+// an updated manifest is saved to a temporary file and its path is returned;
+// if the image registry is not provided or is the default one, the original URI is returned;
+// the second return value indicates whether the temporary file was created and should be removed later
+func setImageRegistry(bopURI, imageRegistry string) (string, bool, error) {
+	if bopURI == "" {
+		return "", false, fmt.Errorf("empty BOP manifest URI")
+	}
+	if imageRegistry == "" || imageRegistry == constants.MirantisImageRegistry {
+		return bopURI, false, nil
+	}
+
+	var manifestBytes []byte
+	var err error
+	if strings.HasPrefix(bopURI, "file://") {
+		manifestBytes, err = readLocalManifest(strings.TrimPrefix(bopURI, "file://"))
+	} else {
+		manifestBytes, err = downloadRemoteManifest(bopURI)
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("unable to obtain BOP manifest: %w", err)
+	}
+
+	manifestBytes = bytes.ReplaceAll(manifestBytes, []byte(constants.MirantisImageRegistry), []byte(imageRegistry))
+
+	tmpManifest, err := os.CreateTemp("", "bop-*.yaml")
+	if err != nil {
+		return "", false, fmt.Errorf("unable to create temporary manifest file: %w", err)
+	}
+
+	defer func() {
+		if err != nil {
+			_ = tmpManifest.Close()
+			_ = os.Remove(tmpManifest.Name())
+		}
+	}()
+
+	writtenN, err := tmpManifest.Write(manifestBytes)
+	if err != nil {
+		return "", false, fmt.Errorf("unable to write temporary manifest file with updated image registry: %w", err)
+	}
+	if writtenN != len(manifestBytes) {
+		err = fmt.Errorf("unable to write temporary manifest file with updated image registry: wrote %d bytes, expected %d", writtenN, len(manifestBytes))
+		return "", false, err
+	}
+	if err = tmpManifest.Close(); err != nil {
+		return "", false, fmt.Errorf("unable to close temporary manifest file: %w", err)
+	}
+
+	return fmt.Sprintf("file://%s", tmpManifest.Name()), true, nil
+}
+
+func readLocalManifest(bopPath string) ([]byte, error) {
+	f, err := os.Open(bopPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open BOP manifest file %s: %w", bopPath, err)
+	}
+	defer f.Close()
+
+	manifestBytes, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read BOP manifest file %s: %w", bopPath, err)
+	}
+
+	return manifestBytes, nil
+}
+
+func downloadRemoteManifest(bopURI string) ([]byte, error) {
+	resp, err := http.Get(bopURI)
+	if err != nil {
+		return nil, fmt.Errorf("unable to download BOP manifest from %s: %w", bopURI, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("got an unexpected status code while downloading BOP manifest from %s: %s", bopURI, resp.Status)
+	}
+
+	manifestBytes := new(bytes.Buffer)
+
+	_, err = io.Copy(manifestBytes, resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read BOP manifest downloaded from %s: %w", bopURI, err)
+	}
+
+	return manifestBytes.Bytes(), nil
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -30,4 +30,6 @@ const (
 	SemverRegexOptionalV = `^[v]?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$`
 	// The k0s semver regex is the same as the optional v semver regex, but with an optional "+k0s.0" at the end
 	K0sSemverRegex = `^[v]?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+(k[0-9a-zA-Z-]s+(?:\.[0-9a-zA-Z-]+)*))?$`
+
+	MirantisImageRegistry = "ghcr.io/mirantiscontainers"
 )


### PR DESCRIPTION
Following up https://github.com/Mirantis/blueprint-operator/pull/107, this PR makes the image registry configurable. 
The PR adds `--image-registry` flag to the apply and upgrade CLI commands.
- The flag sets the image registry in BOP manifest by creating a manifest copy in a temporary file. The registry is replaced in the temporary file and the manifest is applied using the temporary file with the updated registry. After that, the temporary manifest will be automatically removed.
- When the registry is non-empty and different from the default `ghcr.io/mirantiscontainers` it will replace all occurrences of the default registry in the manifest file. 
